### PR TITLE
fix(rbac): grant suppliers scoped access to quotations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ All backend endpoints are served under `API_PREFIX` (default: `/api/v1`).
 - `POST /api/v1/auth/login-email` - Authentication (email-based)
 - `GET /api/v1/products` - List products (public)
 - `POST /api/v1/quotations` - Create quotation (customer only)
+- `GET /api/v1/quotations/supplier` - Quotations including the supplier's products (supplier/admin)
 - `GET /api/v1/orders` - List orders (authenticated)
 - `GET /api/v1/admin/dashboard` - Admin dashboard (admin only)
 - `GET /api/v1/ratings/top-suppliers` - Top suppliers (public)
@@ -221,6 +222,7 @@ After completing any refactoring task:
 - Vulnerabilities: `sqlite3` upgraded to v6, root `overrides` added — 0 findings (2026-04-04)
 - Docker security: `USER node` in backend Dockerfile; DB/Redis ports bound to `127.0.0.1` — fixed (2026-04-04)
 - Test credentials visible in LoginPage UI — wrapped in `import.meta.env.DEV` (2026-04-04)
+- Supplier RBAC: suppliers blocked from quotations (they hit the admin-only `GET /quotations/admin/all`, and the Supplier Dashboard failed with "Access denied"). Added supplier-scoped `GET /quotations/supplier` (server-side filtered to the supplier's products), made `PUT /quotations/supplier/:id` ownership-checked, scoped `getById` for suppliers, fixed the dashboard's broken detail/order navigation, and added the `supplier/quotations/:id` route — fixed (2026-05-29)
 
 ### Open
 1. **Backend tests OOM**: `jest --runInBand` hits heap limit without `--max-old-space-size=4096` in `backend/package.json` test script (CI has it via `NODE_OPTIONS`)

--- a/backend/src/controllers/__tests__/quotationsController.test.ts
+++ b/backend/src/controllers/__tests__/quotationsController.test.ts
@@ -3,6 +3,7 @@ import express, { Request, Response, NextFunction } from 'express';
 import {
   createQuotation,
   getCustomerQuotations,
+  getSupplierQuotations,
   getQuotationById,
   getAllQuotations,
   updateQuotation,
@@ -78,6 +79,20 @@ app.get(
   authenticateJWT,
   requireRole('customer'),
   getCustomerQuotations
+);
+app.get(
+  '/api/quotations/supplier',
+  authenticateJWT,
+  requireRole('supplier', 'admin'),
+  getSupplierQuotations
+);
+app.put(
+  '/api/quotations/supplier/:id',
+  authenticateJWT,
+  requireRole('supplier'),
+  updateQuotationValidation,
+  handleValidationErrors,
+  updateQuotation
 );
 app.get('/api/quotations/:id', authenticateJWT, getQuotationById);
 app.get('/api/admin/quotations', authenticateJWT, requireRole('admin'), getAllQuotations);
@@ -414,6 +429,154 @@ describe('Quotations Controller', () => {
 
       // Assert
       expect(response.body.success).toBe(false);
+    });
+  });
+
+  describe('GET /api/quotations/supplier', () => {
+    it('should return only quotations that include the supplier products', async () => {
+      const mockSupplier = {
+        id: 7,
+        email: 'supplier@example.com',
+        role: 'supplier' as const,
+        cnpj: '12.345.678/0001-90',
+        companyType: 'supplier' as const,
+      };
+      const mockQuotations = [
+        {
+          id: 1,
+          companyId: 5,
+          status: 'pending',
+          items: [{ productId: 1, quantity: 5, product: { id: 1, supplierId: 7 } }],
+          user: { id: 5, email: 'buyer@example.com', role: 'customer' },
+        },
+      ];
+
+      mockAuthenticateJWT.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        req.user = mockSupplier;
+        next();
+      });
+      // findAllForSupplier: first resolve the matching quotation ids, then the full rows
+      MockQuotationItem.findAll.mockResolvedValue([{ quotationId: 1 }] as any);
+      MockQuotation.findAll.mockResolvedValue(mockQuotations as any);
+
+      const response = await request(app).get('/api/quotations/supplier').expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data).toHaveLength(1);
+      expect(response.body.data[0].id).toBe(1);
+      expect(MockQuotationItem.findAll).toHaveBeenCalled();
+    });
+
+    it('should return an empty list when the supplier has no related quotations', async () => {
+      mockAuthenticateJWT.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        req.user = {
+          id: 7,
+          email: 'supplier@example.com',
+          role: 'supplier',
+          cnpj: '12.345.678/0001-90',
+          companyType: 'supplier',
+        };
+        next();
+      });
+      MockQuotationItem.findAll.mockResolvedValue([] as any);
+
+      const response = await request(app).get('/api/quotations/supplier').expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data).toEqual([]);
+      expect(MockQuotation.findAll).not.toHaveBeenCalled();
+    });
+
+    it('should return 403 for customer users', async () => {
+      mockAuthenticateJWT.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        req.user = {
+          id: 1,
+          email: 'customer@example.com',
+          role: 'customer',
+          cnpj: '12.345.678/0001-90',
+          companyType: 'buyer',
+        };
+        next();
+      });
+
+      const response = await request(app).get('/api/quotations/supplier').expect(403);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toContain('Access denied');
+    });
+  });
+
+  describe('PUT /api/quotations/supplier/:id', () => {
+    it('should update a quotation that includes the supplier products', async () => {
+      const supplierQuotation = {
+        id: 1,
+        status: 'pending',
+        adminNotes: null,
+        items: [{ productId: 1, quantity: 5, product: { id: 1, supplierId: 7 } }],
+        update: jest.fn().mockResolvedValue(true),
+      };
+      const updatedQuotation = {
+        id: 1,
+        status: 'processed',
+        adminNotes: null,
+        items: supplierQuotation.items,
+        user: { id: 5, email: 'buyer@example.com', role: 'customer' },
+      };
+
+      mockAuthenticateJWT.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        req.user = {
+          id: 7,
+          email: 'supplier@example.com',
+          role: 'supplier',
+          cnpj: '12.345.678/0001-90',
+          companyType: 'supplier',
+        };
+        next();
+      });
+      // findByIdWithItems (ownership check), then findByIdWithItemsAndUser (reload)
+      MockQuotation.findByPk
+        .mockResolvedValueOnce(supplierQuotation as any)
+        .mockResolvedValueOnce(updatedQuotation as any);
+
+      const response = await request(app)
+        .put('/api/quotations/supplier/1')
+        .send({ status: 'processed' })
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.status).toBe('processed');
+      expect(supplierQuotation.update).toHaveBeenCalled();
+    });
+
+    it('should return 403 when the quotation has no product from the supplier', async () => {
+      const foreignQuotation = {
+        id: 1,
+        status: 'pending',
+        adminNotes: null,
+        items: [{ productId: 2, quantity: 5, product: { id: 2, supplierId: 99 } }],
+        update: jest.fn(),
+      };
+
+      mockAuthenticateJWT.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        req.user = {
+          id: 7,
+          email: 'supplier@example.com',
+          role: 'supplier',
+          cnpj: '12.345.678/0001-90',
+          companyType: 'supplier',
+        };
+        next();
+      });
+      MockQuotation.findByPk.mockResolvedValueOnce(foreignQuotation as any);
+
+      const response = await request(app)
+        .put('/api/quotations/supplier/1')
+        .send({ status: 'processed' })
+        .expect(403);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toBe('Access denied');
+      expect(foreignQuotation.update).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/controllers/quotationsController.ts
+++ b/backend/src/controllers/quotationsController.ts
@@ -36,6 +36,18 @@ export const getCustomerQuotations = asyncHandler(
   }
 );
 
+// Supplier endpoint - returns only quotations that include the supplier's products
+export const getSupplierQuotations = asyncHandler(
+  async (req: AuthenticatedRequest, res: Response) => {
+    const quotations = await quotationService.getForSupplier(req.user!.id);
+
+    res.status(200).json({
+      success: true,
+      data: quotations,
+    });
+  }
+);
+
 export const getQuotationById = asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
   const id = req.params.id as string;
 
@@ -73,10 +85,18 @@ export const updateQuotation = asyncHandler(async (req: AuthenticatedRequest, re
   const { status, adminNotes } = req.body;
 
   try {
-    const updatedQuotation = await quotationService.updateByAdmin(parseInt(id), {
-      status,
-      adminNotes,
-    });
+    // Suppliers are restricted to quotations that include their products; admins
+    // may update any quotation. Role is enforced upstream by requireRole.
+    const updatedQuotation =
+      req.user!.role === 'supplier'
+        ? await quotationService.updateBySupplier(parseInt(id), req.user!.id, {
+            status,
+            adminNotes,
+          })
+        : await quotationService.updateByAdmin(parseInt(id), {
+            status,
+            adminNotes,
+          });
 
     res.status(200).json({
       success: true,
@@ -85,7 +105,8 @@ export const updateQuotation = asyncHandler(async (req: AuthenticatedRequest, re
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to update quotation';
-    const status = message === 'Quotation not found' ? 404 : 400;
+    const status =
+      message === 'Quotation not found' ? 404 : message === 'Access denied' ? 403 : 400;
 
     res.status(status).json({
       success: false,

--- a/backend/src/repositories/__tests__/quotation.repository.test.ts
+++ b/backend/src/repositories/__tests__/quotation.repository.test.ts
@@ -165,6 +165,54 @@ describe('QuotationRepository', () => {
     });
   });
 
+  describe('findAllForSupplier', () => {
+    it('should fetch full quotations for the supplier-owned product ids', async () => {
+      (QuotationItem.findAll as jest.Mock).mockResolvedValue([
+        { quotationId: 1 },
+        { quotationId: 2 },
+        { quotationId: 1 }, // duplicate to verify de-duplication
+      ]);
+      const mockQuotations = [
+        { id: 1, companyId: 5, items: [], user: { id: 5 } },
+        { id: 2, companyId: 6, items: [], user: { id: 6 } },
+      ];
+      (Quotation.findAll as jest.Mock).mockResolvedValue(mockQuotations);
+
+      const result = await quotationRepository.findAllForSupplier(7);
+
+      expect(result).toEqual(mockQuotations);
+      // QuotationItem lookup filters by the supplier through the product include
+      expect(QuotationItem.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: ['quotationId'],
+          include: [
+            expect.objectContaining({
+              model: Product,
+              as: 'product',
+              where: { supplierId: 7 },
+              required: true,
+            }),
+          ],
+          raw: true,
+        })
+      );
+      // Only unique quotation ids should be requested
+      const findAllArg = (Quotation.findAll as jest.Mock).mock.calls[0][0];
+      expect(findAllArg.where.id[Object.getOwnPropertySymbols(findAllArg.where.id)[0]]).toEqual([
+        1, 2,
+      ]);
+    });
+
+    it('should return an empty array when the supplier has no quotations', async () => {
+      (QuotationItem.findAll as jest.Mock).mockResolvedValue([]);
+
+      const result = await quotationRepository.findAllForSupplier(7);
+
+      expect(result).toEqual([]);
+      expect(Quotation.findAll).not.toHaveBeenCalled();
+    });
+  });
+
   describe('create', () => {
     it('should create a new quotation', async () => {
       const quotationData = {

--- a/backend/src/repositories/quotation.repository.ts
+++ b/backend/src/repositories/quotation.repository.ts
@@ -1,3 +1,4 @@
+import { Op } from 'sequelize';
 import Quotation from '../models/Quotation';
 import QuotationItem from '../models/QuotationItem';
 import Product from '../models/Product';
@@ -46,6 +47,37 @@ export const quotationRepository = {
       include: QUOTATION_INCLUDES.withItemsAndUser,
       order: [['createdAt', 'DESC']],
     }),
+
+  // Returns full quotations that contain at least one product owned by the supplier.
+  // The supplier ownership filter is applied server-side to avoid leaking other
+  // suppliers' / customers' quotation data to the client.
+  findAllForSupplier: async (supplierId: number) => {
+    const supplierItems = (await QuotationItem.findAll({
+      attributes: ['quotationId'],
+      include: [
+        {
+          model: Product,
+          as: 'product',
+          attributes: [],
+          where: { supplierId },
+          required: true,
+        },
+      ],
+      raw: true,
+    })) as unknown as Array<{ quotationId: number }>;
+
+    const quotationIds = [...new Set(supplierItems.map(item => item.quotationId))];
+
+    if (quotationIds.length === 0) {
+      return [];
+    }
+
+    return Quotation.findAll({
+      where: { id: { [Op.in]: quotationIds } },
+      include: QUOTATION_INCLUDES.withItemsAndUser,
+      order: [['createdAt', 'DESC']],
+    });
+  },
 
   create: (data: { companyId: number; status: 'pending' | 'processed' | 'completed' | 'rejected'; adminNotes: string | null }) =>
     Quotation.create(data),

--- a/backend/src/routes/quotations.ts
+++ b/backend/src/routes/quotations.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import {
   createQuotation,
   getCustomerQuotations,
+  getSupplierQuotations,
   getQuotationById,
   getAllQuotations,
   updateQuotation,
@@ -36,7 +37,12 @@ router.post(
 );
 router.get('/', requireRole('customer'), getCustomerQuotations);
 
-// Shared routes - customers can view their own, admins can view all
+// Supplier routes - suppliers can view quotations that include their products.
+// Declared before '/:id' so the literal path is not captured as an id param.
+router.get('/supplier', requireRole('supplier', 'admin'), getSupplierQuotations);
+
+// Shared routes - customers can view their own, suppliers their related ones,
+// admins can view all (ownership scoping enforced in the service layer)
 router.get('/:id', getQuotationById);
 router.get('/:id/calculations', getQuotationCalculations);
 

--- a/backend/src/services/__tests__/quotationService.test.ts
+++ b/backend/src/services/__tests__/quotationService.test.ts
@@ -8,6 +8,7 @@ jest.mock('../../repositories', () => ({
     findByIdWithItems: jest.fn(),
     findByIdWithItemsAndUser: jest.fn(),
     findAllForCompany: jest.fn(),
+    findAllForSupplier: jest.fn(),
     findAll: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
@@ -110,6 +111,18 @@ describe('QuotationService', () => {
     });
   });
 
+  describe('getForSupplier', () => {
+    it('should return quotations that include the supplier products', async () => {
+      const mockQuotations = [{ id: 1 }, { id: 2 }];
+      mockQuotationRepo.findAllForSupplier.mockResolvedValue(mockQuotations as any);
+
+      const result = await quotationService.getForSupplier(7);
+
+      expect(mockQuotationRepo.findAllForSupplier).toHaveBeenCalledWith(7);
+      expect(result).toEqual(mockQuotations);
+    });
+  });
+
   describe('getById', () => {
     it('should return quotation for owner customer', async () => {
       const mockQuotation = { id: 1, companyId: 1 };
@@ -142,6 +155,30 @@ describe('QuotationService', () => {
       mockQuotationRepo.findByIdWithItemsAndUser.mockResolvedValue(mockQuotation as any);
 
       await expect(quotationService.getById(1, 1, 'customer')).rejects.toThrow('Access denied');
+    });
+
+    it('should return quotation for supplier that owns one of the products', async () => {
+      const mockQuotation = {
+        id: 1,
+        companyId: 5,
+        items: [{ product: { supplierId: 7 } }],
+      };
+      mockQuotationRepo.findByIdWithItemsAndUser.mockResolvedValue(mockQuotation as any);
+
+      const result = await quotationService.getById(1, 7, 'supplier');
+
+      expect(result).toEqual(mockQuotation);
+    });
+
+    it('should throw access denied for supplier without a matching product', async () => {
+      const mockQuotation = {
+        id: 1,
+        companyId: 5,
+        items: [{ product: { supplierId: 99 } }],
+      };
+      mockQuotationRepo.findByIdWithItemsAndUser.mockResolvedValue(mockQuotation as any);
+
+      await expect(quotationService.getById(1, 7, 'supplier')).rejects.toThrow('Access denied');
     });
   });
 
@@ -214,6 +251,54 @@ describe('QuotationService', () => {
         status: 'processed',
         adminNotes: 'New note',
       });
+    });
+  });
+
+  describe('updateBySupplier', () => {
+    it('should update a quotation that includes the supplier products', async () => {
+      const mockQuotation = {
+        id: 1,
+        status: 'pending',
+        adminNotes: null,
+        items: [{ product: { supplierId: 7 } }],
+      };
+      mockQuotationRepo.findByIdWithItems.mockResolvedValue(mockQuotation as any);
+      mockQuotationRepo.update.mockResolvedValue(undefined as any);
+      mockQuotationRepo.findByIdWithItemsAndUser.mockResolvedValue({
+        id: 1,
+        status: 'processed',
+      } as any);
+
+      const result = await quotationService.updateBySupplier(1, 7, { status: 'processed' });
+
+      expect(mockQuotationRepo.update).toHaveBeenCalledWith(mockQuotation, {
+        status: 'processed',
+        adminNotes: null,
+      });
+      expect(result).toBeDefined();
+    });
+
+    it('should throw when quotation not found', async () => {
+      mockQuotationRepo.findByIdWithItems.mockResolvedValue(null);
+
+      await expect(
+        quotationService.updateBySupplier(999, 7, { status: 'processed' })
+      ).rejects.toThrow('Quotation not found');
+    });
+
+    it('should throw access denied when supplier has no matching product', async () => {
+      const mockQuotation = {
+        id: 1,
+        status: 'pending',
+        adminNotes: null,
+        items: [{ product: { supplierId: 99 } }],
+      };
+      mockQuotationRepo.findByIdWithItems.mockResolvedValue(mockQuotation as any);
+
+      await expect(
+        quotationService.updateBySupplier(1, 7, { status: 'processed' })
+      ).rejects.toThrow('Access denied');
+      expect(mockQuotationRepo.update).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/services/quotation.service.ts
+++ b/backend/src/services/quotation.service.ts
@@ -54,6 +54,10 @@ class QuotationService {
     return quotationRepository.findAllForCompany(companyId);
   }
 
+  async getForSupplier(supplierId: number) {
+    return quotationRepository.findAllForSupplier(supplierId);
+  }
+
   async getById(id: number, userId: number, userRole: string) {
     const quotation = await quotationRepository.findByIdWithItemsAndUser(id);
 
@@ -63,6 +67,11 @@ class QuotationService {
 
     // Access control
     if (userRole === 'customer' && quotation.companyId !== userId) {
+      throw new Error('Access denied');
+    }
+
+    // Suppliers may only access quotations that include at least one of their products
+    if (userRole === 'supplier' && !this.containsSupplierProduct(quotation, userId)) {
       throw new Error('Access denied');
     }
 
@@ -92,6 +101,41 @@ class QuotationService {
     });
 
     return quotationRepository.findByIdWithItemsAndUser(id);
+  }
+
+  async updateBySupplier(
+    id: number,
+    supplierId: number,
+    data: {
+      status?: 'pending' | 'processed' | 'completed' | 'rejected';
+      adminNotes?: string | null;
+    }
+  ) {
+    const quotation = await quotationRepository.findByIdWithItems(id);
+
+    if (!quotation) {
+      throw new Error('Quotation not found');
+    }
+
+    // A supplier may only update quotations that include at least one of their products
+    if (!this.containsSupplierProduct(quotation, supplierId)) {
+      throw new Error('Access denied');
+    }
+
+    await quotationRepository.update(quotation, {
+      status: data.status || quotation.status,
+      adminNotes: data.adminNotes !== undefined ? data.adminNotes : quotation.adminNotes,
+    });
+
+    return quotationRepository.findByIdWithItemsAndUser(id);
+  }
+
+  // Checks whether a quotation (loaded with its items and products) contains at
+  // least one product owned by the given supplier.
+  private containsSupplierProduct(quotation: unknown, supplierId: number): boolean {
+    const items =
+      (quotation as { items?: Array<{ product?: { supplierId?: number } }> }).items ?? [];
+    return items.some(item => item.product?.supplierId === supplierId);
   }
 
   async processWithCalculations(id: number, _calculations: Record<string, unknown>) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -169,6 +169,14 @@ const App: React.FC = () => {
                       </ProtectedRoute>
                     }
                   />
+                  <Route
+                    path='supplier/quotations/:id'
+                    element={
+                      <ProtectedRoute allowedRoles={['supplier', 'admin']}>
+                        <QuotationDetailPage />
+                      </ProtectedRoute>
+                    }
+                  />
                 </Route>
 
                 {/* Catch all - redirect to home */}

--- a/frontend/src/pages/QuotationDetailPage.tsx
+++ b/frontend/src/pages/QuotationDetailPage.tsx
@@ -53,7 +53,15 @@ const QuotationDetailPage: React.FC = () => {
 
   const isAdmin = user?.role === 'admin';
   const isCustomer = user?.role === 'customer';
+  const isSupplier = user?.role === 'supplier';
   const canCreateOrder = isCustomer && quotation?.status === 'processed';
+
+  // Send each role back to a list page it is actually allowed to access.
+  const backTo = isAdmin
+    ? '/admin/quotations'
+    : isSupplier
+      ? '/supplier/quotations'
+      : '/my-quotations';
 
   const handleCreateOrder = async () => {
     if (!quotation) return;
@@ -133,7 +141,7 @@ const QuotationDetailPage: React.FC = () => {
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
             <IconButton
               component={Link}
-              to={isAdmin ? '/admin/quotations' : '/my-quotations'}
+              to={backTo}
               edge='start'
               sx={{ '&:hover': { bgcolor: 'action.hover' } }}
             >

--- a/frontend/src/pages/SupplierDashboardPage.tsx
+++ b/frontend/src/pages/SupplierDashboardPage.tsx
@@ -114,7 +114,9 @@ const SupplierDashboardPage: React.FC = () => {
 
   const loadPendingQuotations = async () => {
     try {
-      const data = await quotationsService.getAllQuotations();
+      // Supplier-scoped endpoint: returns only quotations that include this
+      // supplier's products (filtered server-side).
+      const data = await quotationsService.getSupplierQuotations();
       const pending = data
         .filter((quote: Quotation) => quote.status === 'pending' || quote.status === 'processed')
         .slice(0, 4); // match new UI length
@@ -594,7 +596,7 @@ const SupplierDashboardPage: React.FC = () => {
                       cursor: 'pointer',
                       '&:hover': { opacity: 0.8 },
                     }}
-                    onClick={() => navigate(`/supplier/orders/${order.id}`)}
+                    onClick={() => navigate('/supplier/orders')}
                   >
                     <Box
                       sx={{

--- a/frontend/src/pages/SupplierQuotationsPage.tsx
+++ b/frontend/src/pages/SupplierQuotationsPage.tsx
@@ -48,7 +48,6 @@ import {
 } from '@mui/icons-material';
 import { Quotation } from '@shared/types';
 import { quotationsService } from '../services/quotationsService';
-import { useAuth } from '../contexts/AuthContext';
 import toast from 'react-hot-toast';
 
 interface QuotationResponse {
@@ -103,26 +102,20 @@ const SupplierQuotationsPage: React.FC = () => {
   const [dateFilter, setDateFilter] = useState<string>('');
   const [priorityFilter, setPriorityFilter] = useState<string>('');
 
-  const { user } = useAuth();
-
   const loadQuotations = useCallback(async () => {
     setLoading(true);
     try {
-      // This would ideally be a supplier-specific endpoint
-      // For now, using the admin endpoint and filtering
-      const data = await quotationsService.getAllQuotations();
-      // Filter quotations that include products from this supplier
-      const supplierQuotations = data.filter((quotation: Quotation) =>
-        quotation.items?.some(item => item.product?.supplierId === user?.id)
-      );
-      setQuotations(supplierQuotations);
+      // Supplier-scoped endpoint: the backend already restricts results to
+      // quotations that include this supplier's products.
+      const data = await quotationsService.getSupplierQuotations();
+      setQuotations(data);
     } catch (_error) {
       console.error('Error loading quotations:', _error);
       toast.error('Error loading quotations');
     } finally {
       setLoading(false);
     }
-  }, [user?.id]);
+  }, []);
 
   useEffect(() => {
     loadQuotations();

--- a/frontend/src/pages/__tests__/SupplierDashboardPage.test.tsx
+++ b/frontend/src/pages/__tests__/SupplierDashboardPage.test.tsx
@@ -14,7 +14,7 @@ vi.mock('../../services/ordersService', () => ({
 
 vi.mock('../../services/quotationsService', () => ({
   quotationsService: {
-    getAllQuotations: vi.fn(),
+    getSupplierQuotations: vi.fn(),
   },
 }));
 
@@ -107,7 +107,7 @@ describe('SupplierDashboardPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(ordersService.getUserOrders).mockResolvedValue({ orders: mockOrders });
-    vi.mocked(quotationsService.getAllQuotations).mockResolvedValue(mockQuotations);
+    vi.mocked(quotationsService.getSupplierQuotations).mockResolvedValue(mockQuotations);
   });
 
   it('renders dashboard header with supplier branding', async () => {
@@ -146,7 +146,7 @@ describe('SupplierDashboardPage', () => {
     await renderPage();
 
     await waitFor(() => {
-      expect(quotationsService.getAllQuotations).toHaveBeenCalledTimes(1);
+      expect(quotationsService.getSupplierQuotations).toHaveBeenCalledTimes(1);
     });
 
     await waitFor(() => {
@@ -167,14 +167,14 @@ describe('SupplierDashboardPage', () => {
   it('handles error when loading dashboard data', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.mocked(ordersService.getUserOrders).mockRejectedValue(new Error('Network error'));
-    vi.mocked(quotationsService.getAllQuotations).mockRejectedValue(new Error('Network error'));
+    vi.mocked(quotationsService.getSupplierQuotations).mockRejectedValue(new Error('Network error'));
 
     await renderPage();
 
     await waitFor(
       () => {
         expect(ordersService.getUserOrders).toHaveBeenCalled();
-        expect(quotationsService.getAllQuotations).toHaveBeenCalled();
+        expect(quotationsService.getSupplierQuotations).toHaveBeenCalled();
       },
       { timeout: 10000 }
     );

--- a/frontend/src/pages/__tests__/SupplierQuotationsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SupplierQuotationsPage.test.tsx
@@ -9,7 +9,7 @@ import toast from 'react-hot-toast';
 // Mock services
 vi.mock('../../services/quotationsService', () => ({
   quotationsService: {
-    getAllQuotations: vi.fn(),
+    getSupplierQuotations: vi.fn(),
   },
 }));
 
@@ -127,11 +127,11 @@ const renderPage = async () => {
 describe('SupplierQuotationsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(quotationsService.getAllQuotations).mockResolvedValue(mockQuotations);
+    vi.mocked(quotationsService.getSupplierQuotations).mockResolvedValue(mockQuotations);
   });
 
   it('shows loading spinner while fetching quotations', async () => {
-    vi.mocked(quotationsService.getAllQuotations).mockImplementation(
+    vi.mocked(quotationsService.getSupplierQuotations).mockImplementation(
       () => new Promise(resolve => setTimeout(() => resolve(mockQuotations), 100))
     );
 
@@ -206,7 +206,7 @@ describe('SupplierQuotationsPage', () => {
   });
 
   it('handles error when loading quotations fails', async () => {
-    vi.mocked(quotationsService.getAllQuotations).mockRejectedValue(new Error('Network error'));
+    vi.mocked(quotationsService.getSupplierQuotations).mockRejectedValue(new Error('Network error'));
 
     await renderPage();
 
@@ -409,7 +409,7 @@ describe('SupplierQuotationsPage', () => {
 
   it('shows empty state for processed tab when no processed quotations', async () => {
     const pendingOnly = [mockQuotations[0]]; // only pending
-    vi.mocked(quotationsService.getAllQuotations).mockResolvedValue(pendingOnly);
+    vi.mocked(quotationsService.getSupplierQuotations).mockResolvedValue(pendingOnly);
 
     await renderPage();
     const user = userEvent.setup();
@@ -428,7 +428,7 @@ describe('SupplierQuotationsPage', () => {
 
   it('shows empty state for completed tab when no completed quotations', async () => {
     const pendingOnly = [mockQuotations[0]];
-    vi.mocked(quotationsService.getAllQuotations).mockResolvedValue(pendingOnly);
+    vi.mocked(quotationsService.getSupplierQuotations).mockResolvedValue(pendingOnly);
 
     await renderPage();
     const user = userEvent.setup();
@@ -450,7 +450,7 @@ describe('SupplierQuotationsPage', () => {
       ...mockQuotations[0],
       requestedDeliveryDate: undefined,
     };
-    vi.mocked(quotationsService.getAllQuotations).mockResolvedValue([quotationWithoutDeliveryDate]);
+    vi.mocked(quotationsService.getSupplierQuotations).mockResolvedValue([quotationWithoutDeliveryDate]);
 
     await renderPage();
     const user = userEvent.setup();
@@ -528,7 +528,7 @@ describe('SupplierQuotationsPage', () => {
       ...mockQuotations[0],
       adminNotes: 'Approved by admin',
     };
-    vi.mocked(quotationsService.getAllQuotations).mockResolvedValue([quotationWithNotes]);
+    vi.mocked(quotationsService.getSupplierQuotations).mockResolvedValue([quotationWithNotes]);
 
     await renderPage();
     const user = userEvent.setup();
@@ -558,7 +558,7 @@ describe('SupplierQuotationsPage', () => {
         },
       ],
     };
-    vi.mocked(quotationsService.getAllQuotations).mockResolvedValue([quotationWithSpecs]);
+    vi.mocked(quotationsService.getSupplierQuotations).mockResolvedValue([quotationWithSpecs]);
 
     await renderPage();
     const user = userEvent.setup();
@@ -578,7 +578,7 @@ describe('SupplierQuotationsPage', () => {
 
   it('shows No pending quotations found when pending tab is empty', async () => {
     // Only non-pending quotations
-    vi.mocked(quotationsService.getAllQuotations).mockResolvedValue([
+    vi.mocked(quotationsService.getSupplierQuotations).mockResolvedValue([
       mockQuotations[1],
       mockQuotations[2],
     ]);
@@ -616,7 +616,7 @@ describe('SupplierQuotationsPage', () => {
         },
       })),
     };
-    vi.mocked(quotationsService.getAllQuotations).mockResolvedValue([quotationWith4Items]);
+    vi.mocked(quotationsService.getSupplierQuotations).mockResolvedValue([quotationWith4Items]);
 
     await renderPage();
 
@@ -673,7 +673,7 @@ describe('SupplierQuotationsPage', () => {
       ...mockQuotations[0],
       createdAt: new Date().toISOString(),
     };
-    vi.mocked(quotationsService.getAllQuotations).mockResolvedValue([todayQuotation]);
+    vi.mocked(quotationsService.getSupplierQuotations).mockResolvedValue([todayQuotation]);
 
     await renderPage();
 
@@ -701,7 +701,7 @@ describe('SupplierQuotationsPage', () => {
       createdAt: threeDaysAgo,
     };
     // mockQuotations[1] has createdAt from 2026-03-14 which is older than a week
-    vi.mocked(quotationsService.getAllQuotations).mockResolvedValue([
+    vi.mocked(quotationsService.getSupplierQuotations).mockResolvedValue([
       recentQuotation,
       mockQuotations[1],
     ]);
@@ -738,7 +738,7 @@ describe('SupplierQuotationsPage', () => {
       ...mockQuotations[1],
       createdAt: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString(),
     };
-    vi.mocked(quotationsService.getAllQuotations).mockResolvedValue([
+    vi.mocked(quotationsService.getSupplierQuotations).mockResolvedValue([
       recentQuotation,
       oldQuotation,
     ]);

--- a/frontend/src/services/__tests__/quotationsService.test.ts
+++ b/frontend/src/services/__tests__/quotationsService.test.ts
@@ -225,6 +225,34 @@ describe('QuotationsService', () => {
     });
   });
 
+  describe('getSupplierQuotations', () => {
+    it('should fetch quotations for the authenticated supplier', async () => {
+      const quotations = [mockQuotation];
+      mockApi.get.mockResolvedValue({ success: true, data: quotations });
+
+      const result = await quotationsService.getSupplierQuotations();
+
+      expect(mockApi.get).toHaveBeenCalledWith('/quotations/supplier');
+      expect(result).toHaveLength(1);
+    });
+
+    it('should throw when response is unsuccessful', async () => {
+      mockApi.get.mockResolvedValue({ success: false, error: 'Supplier access required' });
+
+      await expect(quotationsService.getSupplierQuotations()).rejects.toThrow(
+        'Supplier access required'
+      );
+    });
+
+    it('should throw default message when no error field', async () => {
+      mockApi.get.mockResolvedValue({ success: false });
+
+      await expect(quotationsService.getSupplierQuotations()).rejects.toThrow(
+        'Failed to fetch supplier quotations'
+      );
+    });
+  });
+
   describe('getAllQuotations', () => {
     it('should fetch all quotations for admin', async () => {
       const quotations = [mockQuotation];

--- a/frontend/src/services/quotationsService.ts
+++ b/frontend/src/services/quotationsService.ts
@@ -160,6 +160,17 @@ class QuotationsService {
     return response.data;
   }
 
+  // Supplier methods
+  async getSupplierQuotations(): Promise<Quotation[]> {
+    const response = await apiService.get<ApiResponse<Quotation[]>>('/quotations/supplier');
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error || 'Failed to fetch supplier quotations');
+    }
+
+    return response.data;
+  }
+
   // Admin methods
   async getAllQuotations(): Promise<Quotation[]> {
     const response = await apiService.get<ApiResponse<Quotation[]>>('/quotations/admin/all');


### PR DESCRIPTION
## Summary

Grants suppliers scoped access to quotations that include their own products, and repairs the supplier dashboard. Authorization is enforced **server-side** in the service/repository layers, not just via route roles.

## Endpoints

- `GET /quotations/supplier` — `requireRole('supplier', 'admin')`; declared before `/:id` so the literal path isn't captured as an id param.
- `PUT /quotations/supplier/:id` — `requireRole('supplier')`; routed to `updateBySupplier`.
- `GET /quotations/:id` — suppliers now permitted, but scoped.

## Authorization model (verified)

- **List** (`findAllForSupplier`): filters `QuotationItem → Product` by `where: { supplierId }, required: true`, returning only the supplier's related quotation IDs. No cross-supplier/customer data leakage.
- **Read** (`getById`): rejects suppliers with `Access denied` unless the quotation contains one of their products (`containsSupplierProduct`). Customer ownership and admin-unrestricted paths unchanged.
- **Update** (`updateBySupplier`): loads items and enforces `containsSupplierProduct` before any write.
- Error mapping: `Access denied` → **403**, `Quotation not found` → **404**.

## Frontend

- New `getSupplierQuotations` service call; `SupplierDashboardPage` / `SupplierQuotationsPage` / `QuotationDetailPage` wired to the supplier endpoints; route added in `App.tsx`.

## Validation (local, this branch)

| Gate | Result |
| --- | --- |
| backend build (tsc) | PASS |
| backend lint | PASS |
| backend tests | PASS (85/85) |
| frontend lint | PASS |
| frontend tests | PASS |
| frontend build (vite) | PASS |

Conflict-free with `main` (zero file overlap with the recent ProductCard commits).
